### PR TITLE
Don't change the behavior of Base.esc

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,8 +2,6 @@ export @esc, isexpr, isline, rmlines, unblock, namify, isdef, longdef, shortdef,
 
 assoc!(d, k, v) = (d[k] = v; d)
 
-Base.esc(xs::Union{AbstractArray, Tuple}) = map(esc, xs)
-
 macro esc(xs...)
   :($([:($x = esc($x)) for x in esc(xs)]...);)
 end


### PR DESCRIPTION
If you need to map esc across an array or tuple, use map. Don't globally
change Base semantics depending whether or not this package is being used.

```
julia> esc([1,2])
:($(Expr(:escape, [1,2])))

julia> Pkg.checkout("MacroTools")
INFO: Checking out MacroTools master...
INFO: Pulling MacroTools latest master...
INFO: No packages to install, update or remove

julia> using MacroTools # or any other package that transitively depends on it

julia> esc([1,2])
2-element Array{Expr,1}:
 :($(Expr(:escape, 1)))
 :($(Expr(:escape, 2)))
```