### PR TITLE
also test against julia 0.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - release
   - nightly
 notifications:


### PR DESCRIPTION
still supported according to REQUIRE, and now that there are a few tests, Travis should be turned on